### PR TITLE
Don't validate the request state when InResponseTo is empty

### DIFF
--- a/src/AerialShip/SamlSPBundle/Bridge/AssertionConsumer.php
+++ b/src/AerialShip/SamlSPBundle/Bridge/AssertionConsumer.php
@@ -140,14 +140,16 @@ class AssertionConsumer implements RelyingPartyInterface
     }
 
     protected function validateState(Response $response) {
-        $requestState = $this->requestStore->get($response->getInResponseTo());
-        if (!$requestState) {
-            throw new \RuntimeException('Got response to a request that was not made');
+        if ($response->getInResponseTo()) {
+            $requestState = $this->requestStore->get($response->getInResponseTo());
+            if (!$requestState) {
+                throw new \RuntimeException('Got response to a request that was not made');
+            }
+            if ($requestState->getDestination() != $response->getIssuer()) {
+                throw new \RuntimeException('Got response from different issuer');
+            }
+            $this->requestStore->remove($requestState);
         }
-        if ($requestState->getDestination() != $response->getIssuer()) {
-            throw new \RuntimeException('Got response from different issuer');
-        }
-        $this->requestStore->remove($requestState);
     }
 
     protected function validateStatus(Response $response) {


### PR DESCRIPTION
Based on change in lightsaml (see pull request aerialship/lightsaml#15). No need to validate the request state if it was not in response to a triggered request.
