### PR TITLE
Pass SP signing provider to AuthnRequestBuilder

### DIFF
--- a/src/AerialShip/SamlSPBundle/Bridge/AssertionConsumer.php
+++ b/src/AerialShip/SamlSPBundle/Bridge/AssertionConsumer.php
@@ -72,7 +72,8 @@ class AssertionConsumer implements RelyingPartyInterface
         $response = $this->getSamlResponse($request);
         $serviceInfo = $this->serviceInfoCollection->findByIDPEntityID($response->getIssuer());
 
-        $this->validateResponse($serviceInfo, $response, $request);
+        $serviceInfo->getSpProvider()->setRequest($request);
+        $this->validateResponse($serviceInfo, $response);
 
         $assertion = $this->getSingleAssertion($response);
 

--- a/src/AerialShip/SamlSPBundle/Bridge/AssertionConsumer.php
+++ b/src/AerialShip/SamlSPBundle/Bridge/AssertionConsumer.php
@@ -72,8 +72,7 @@ class AssertionConsumer implements RelyingPartyInterface
         $response = $this->getSamlResponse($request);
         $serviceInfo = $this->serviceInfoCollection->findByIDPEntityID($response->getIssuer());
 
-        $serviceInfo->getSpProvider()->setRequest($request);
-        $this->validateResponse($serviceInfo, $response);
+        $this->validateResponse($serviceInfo, $response, $request);
 
         $assertion = $this->getSingleAssertion($response);
 

--- a/src/AerialShip/SamlSPBundle/Bridge/Authenticate.php
+++ b/src/AerialShip/SamlSPBundle/Bridge/Authenticate.php
@@ -80,8 +80,9 @@ class Authenticate implements RelyingPartyInterface
 
         $idpED = $serviceInfo->getIdpProvider()->getEntityDescriptor();
         $spMeta = $serviceInfo->getSpMetaProvider()->getSpMeta();
+        $signingProvider = $serviceInfo->getSpSigningProvider();
 
-        $builder = new AuthnRequestBuilder($spED, $idpED, $spMeta);
+        $builder = new AuthnRequestBuilder($spED, $idpED, $spMeta, $signingProvider);
         $message = $builder->build();
 
         $binding = $this->bindingManager->instantiate($spMeta->getAuthnRequestBinding());


### PR DESCRIPTION
If SP signing configuration is set, pass it to AuthnRequestBuilder so AuthnRequest is properly signed. Needs  lightsaml with pull request AlbertBrand/lightsaml@b6b80b2e7b71c36e69d10b11805c7e18c172ee81 applied.