### PR TITLE
Fix SpProvider missing Request

### DIFF
--- a/src/AerialShip/SamlSPBundle/Bridge/AssertionConsumer.php
+++ b/src/AerialShip/SamlSPBundle/Bridge/AssertionConsumer.php
@@ -72,7 +72,8 @@ class AssertionConsumer implements RelyingPartyInterface
         $response = $this->getSamlResponse($request);
         $serviceInfo = $this->serviceInfoCollection->findByIDPEntityID($response->getIssuer());
 
-        $this->validateResponse($serviceInfo, $response, $request);
+        $serviceInfo->getSpProvider()->setRequest($request);
+        $this->validateResponse($serviceInfo, $response);
 
         $assertion = $this->getSingleAssertion($response);
 


### PR DESCRIPTION
Set provided Request on SpProvider, fixes missing request exception in ACS when no base_url is provided.
