### PR TITLE
Fix service configuration merge causing loss of service names

### DIFF
--- a/src/AerialShip/SamlSPBundle/DependencyInjection/Security/Factory/SamlSpFactory.php
+++ b/src/AerialShip/SamlSPBundle/DependencyInjection/Security/Factory/SamlSpFactory.php
@@ -44,6 +44,7 @@ class SamlSpFactory extends AbstractFactory
             ->arrayNode('services')
                 ->isRequired()
                 ->requiresAtLeastOneElement()
+                ->useAttributeAsKey('name')
                 ->prototype('array')
                     ->children()
                         ->arrayNode('idp')->isRequired()


### PR DESCRIPTION
Small change in how service configuration is merged, which previously caused loss of service names due to array key flattening when merging two or more configurations.
