### PR TITLE
Add ID to response message

### DIFF
--- a/src/AerialShip/SamlSPBundle/Bridge/LogoutReceiveRequest.php
+++ b/src/AerialShip/SamlSPBundle/Bridge/LogoutReceiveRequest.php
@@ -2,6 +2,7 @@
 
 namespace AerialShip\SamlSPBundle\Bridge;
 
+use AerialShip\LightSaml\Helper;
 use AerialShip\LightSaml\Meta\SerializationContext;
 use AerialShip\LightSaml\Model\Metadata\KeyDescriptor;
 use AerialShip\LightSaml\Model\Metadata\Service\SingleLogoutService;
@@ -75,6 +76,7 @@ class LogoutReceiveRequest extends LogoutBase implements RelyingPartyInterface
         $this->deleteSSOState($arrStates);
 
         $logoutResponse = new LogoutResponse();
+        $logoutResponse->setID(Helper::generateID());
         $logoutResponse->setIssuer($serviceInfo->getSpProvider()->getEntityDescriptor()->getEntityID());
         $logoutResponse->setInResponseTo($logoutRequest->getID());
 


### PR DESCRIPTION
Without it I get a missing ID exception in `Message::prepareForXml()` when logging out.
