### PR TITLE
Enhancement - Remove usage of deprecated SecurityContextInterface.

### DIFF
--- a/src/AerialShip/SamlSPBundle/Controller/SecurityController.php
+++ b/src/AerialShip/SamlSPBundle/Controller/SecurityController.php
@@ -3,8 +3,9 @@
 namespace AerialShip\SamlSPBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Security;
 
 class SecurityController extends Controller
 {
@@ -38,10 +39,16 @@ class SecurityController extends Controller
         throw new \RuntimeException('You must configure the discovery path path to be handled by the firewall using aerial_ship_saml_sp in your security firewall configuration.');
     }
 
-    public function failureAction()
+
+    /**
+     * @param Request $request
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function failureAction(Request $request)
     {
         /** @var $error AuthenticationException */
-        $error = $this->getRequest()->getSession()->get(SecurityContextInterface::AUTHENTICATION_ERROR);
+        $error = $request->getSession()->get(Security::AUTHENTICATION_ERROR);
         return $this->render('AerialShipSamlSPBundle::failure.html.twig', array('error'=>$error));
     }
 }


### PR DESCRIPTION
Applied changes to remove deprecated code on `SecurityController` according to:
http://symfony.com/blog/new-in-symfony-2-6-security-component-improvements