### PR TITLE
Allow external code coverage for Scrutinizer.

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -2,6 +2,7 @@ imports:
     - php
 
 tools:
+    external_code_coverage: true
     php_cpd: true
     php_pdepend: true
     php_mess_detector:


### PR DESCRIPTION
Looks like travis is not able to send code coverage to scrutinizer.
Option `external_code_coverage: true` was missing.