### PR TITLE
Fixing sessionIndex length

### DIFF
--- a/src/AerialShip/SamlSPBundle/Resources/config/doctrine-mapping/SSOState.orm.xml
+++ b/src/AerialShip/SamlSPBundle/Resources/config/doctrine-mapping/SSOState.orm.xml
@@ -10,7 +10,7 @@
 
         <field name="authenticationServiceName" column="auth_svc_name" type="string" length="32" />
 
-        <field name="sessionIndex" column="session_index" type="string" length="255" nullable="true" />
+        <field name="sessionIndex" column="session_index" type="string" length="512" nullable="true" />
 
         <field name="nameID" column="name_id" type="string" length="64" />
 


### PR DESCRIPTION
Because it sometimes is larger than 255 (so it won't be stored entirely) and that breaks the SSO with an odd "SSO session has expired" message.